### PR TITLE
Remove constructor from interface

### DIFF
--- a/src/Model/Message/MessageInterface.php
+++ b/src/Model/Message/MessageInterface.php
@@ -15,13 +15,6 @@ interface MessageInterface
 {
 
     /**
-     * MessageInterface constructor.
-     * @param SenderInterface $sender
-     * @param RecipientInterface $recipient
-     */
-    public function __construct(SenderInterface $sender, RecipientInterface $recipient);
-
-    /**
      * @return SenderInterface
      */
     public function getSender();

--- a/src/Model/Recipient/RecipientInterface.php
+++ b/src/Model/Recipient/RecipientInterface.php
@@ -8,12 +8,6 @@ namespace MassimoFilippi\MailModule\Model\Recipient;
  */
 interface RecipientInterface
 {
-    /**
-     * RecipientInterface constructor.
-     * @param string $email
-     * @param string|null $name
-     */
-    public function __construct($email, $name = null);
 
     /**
      * @return string

--- a/src/Model/ReplyTo/ReplyToInterface.php
+++ b/src/Model/ReplyTo/ReplyToInterface.php
@@ -8,12 +8,6 @@ namespace MassimoFilippi\MailModule\Model\ReplyTo;
  */
 interface ReplyToInterface
 {
-    /**
-     * ReplyToInterface constructor.
-     * @param string $email
-     * @param string|null $name
-     */
-    public function __construct($email, $name = null);
 
     /**
      * @return string

--- a/src/Model/Sender/SenderInterface.php
+++ b/src/Model/Sender/SenderInterface.php
@@ -8,12 +8,6 @@ namespace MassimoFilippi\MailModule\Model\Sender;
  */
 interface SenderInterface
 {
-    /**
-     * SenderInterface constructor.
-     * @param string $email
-     * @param string|null $name
-     */
-    public function __construct($email, $name = null);
 
     /**
      * @return string


### PR DESCRIPTION
While it is technically possible to add the constructor to the Interface, Interfaces should not define the constructor because that would be an implementation detail of an implementing class. An Interface should just define the public API other collaborators can call upon. That is, they should not enforce a particular implementation.

If you'd put a constructor asking for a database connection in the Interface, you'd limit the concrete classes to the dependencies in the constructor signature. If a concrete class implementing the Interface needs different (because it's saving to a Webservice) or additional (maybe a Logger) dependency you cannot make that work with your Interface.

https://stackoverflow.com/a/13271397